### PR TITLE
Fix code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/packages/safe-apps-sdk/dist/cjs/communication/index.js
+++ b/packages/safe-apps-sdk/dist/cjs/communication/index.js
@@ -33,7 +33,7 @@ class PostMessageCommunicator {
             return !emptyOrMalformed && sentFromParentEl && allowedSDKVersion && validOrigin;
         };
         this.logIncomingMessage = (msg) => {
-            console.info(`Safe Apps SDK v1: A message was received from origin ${msg.origin}. `, msg.data);
+            console.info("Safe Apps SDK v1: A message was received from origin %s. ", msg.origin, msg.data);
         };
         this.onParentMessage = (msg) => {
             if (this.isValidMessage(msg)) {


### PR DESCRIPTION
Fixes [https://github.com/Civilized-farms/safe-apps-sdk/security/code-scanning/3](https://github.com/Civilized-farms/safe-apps-sdk/security/code-scanning/3)

To fix the problem, we need to ensure that the `msg.origin` value is safely included in the log message without allowing any format specifiers to be interpreted. The best way to achieve this is to use a `%s` specifier in the format string and pass the `msg.origin` as a separate argument to the `console.info` function. This approach ensures that the `msg.origin` is treated as a plain string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
